### PR TITLE
TravisCI: Limit concurrency of test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
   - ./.travis_long stack --no-terminal --skip-ghc-check build --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --bench --only-snapshot
 
 script:
-  - stack --no-terminal --skip-ghc-check build --pedantic --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --bench --no-run-benchmarks
+  - stack --no-terminal --skip-ghc-check build --pedantic --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --test-arguments "+RTS -N2" --bench --no-run-benchmarks


### PR DESCRIPTION
Whilst the tests take +- 2s to run on my development machine, they take > 200s on TravisCI. This is an attempt to limit the concurrency level, since TravisCI only permits 1.5 cores per container, whilst the machine info could expose more (and hence the testsuite using an unreasonable number of HECs).
