### PR TITLE
Add performance numbers to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ For an introduction on erasure coding, see the post on the [Backblaze blog](http
 
 Package home: https://github.com/NicolasT/reedsolomon
 
+# Performance
+Performance depends mainly on the number of parity shards. In rough terms, doubling the number of parity shards will double the encoding time.
+
+Here are the throughput numbers with some different selections of data and parity shards. For reference each shard is 1MB random data, and 1 CPU core is used for encoding.
+
+| Data | Parity | Parity | SSSE3 MB/s  |
+|------|--------|--------|-------------|
+| 5    | 2      | 40%    | 3641,66     |
+| 10   | 2      | 20%    | 3951,01     |
+| 10   | 4      | 40%    | 1821,16     |
+| 50   | 20     | 40%    |  398,09     |
+
+Example of performance on Intel(R) Core(TM) i7-4600U CPU @ 3.30GHz - 2 physical cores, 4 logical cores (note: `/proc/cpuinfo` mentions 2.10GHz only). The example uses 10 blocks with 16MB data each and 4 parity blocks.
+
+| Threads | MB/s    | Speed |
+|---------|---------|-------|
+| 1       | 1551,89 | 100%  |
+
 # Links
 * [Backblaze Open Sources Reed-Solomon Erasure Coding Source Code](https://www.backblaze.com/blog/reed-solomon/).
 * [GolangReedSolomon](https://github.com/klauspost/reedsolomon). Compatible Go library by Klaus Post.


### PR DESCRIPTION
Numbers retrieved on my laptop, using `reedsolomon-simple-bench` with appropriate arguments. Throughput calculated using the average iteration time (i.e. not the mean throughput reported by the tool).

Laptop specs:

```
$ grep '^model name' /proc/cpuinfo | head -n1
model name      : Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz
$ cat /etc/redhat-release
Fedora release 22 (Twenty Two)
$ uname -srvmpio
Linux 4.2.5-201.fc22.x86_64 #1 SMP Wed Oct 28 20:00:23 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
```

CPU specifications: http://ark.intel.com/products/76616/Intel-Core-i7-4600U-Processor-4M-Cache-up-to-3_30-GHz
