### PR TITLE
TravisCI: Run benchmarks and scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,10 @@ install:
   - ./.travis_long stack --no-terminal --skip-ghc-check build --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --bench --only-snapshot
 
 script:
-  - stack --no-terminal --skip-ghc-check build --pedantic --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --test-arguments "+RTS -N2" --bench --no-run-benchmarks
+  - stack --no-terminal --skip-ghc-check build --pedantic --ghc-options "-pgmc gcc-5 -pgmlo opt-3.5 -pgmlc llc-3.5" --test --test-arguments "+RTS -N2" --bench
+
+  - stack exec reedsolomon-simple-bench 5 2 $(( 5 * 1024 * 1024 ))
+  - stack exec reedsolomon-simple-bench 10 2 $(( 10 * 1024 * 1024 ))
+  - stack exec reedsolomon-simple-bench 10 4 $(( 10 * 1024 * 1024 ))
+  - stack exec reedsolomon-simple-bench 50 20 $(( 50 * 1024 * 1024 ))
+  - stack exec reedsolomon-simple-bench 10 4 $(( 160 * 1024 * 1024 ))


### PR DESCRIPTION
This patch changes the TravisCI script to run the `stack bench` target, as well as a couple of scenarios using `reedsolomon-simple-bench`.

Whilst TravisCI is not a reliable benchmarking platform/system, the results could give some indication/rough estimates of throughput provided by the library.
