### PR TITLE
cbits: Actually dispatch on AVX

### DIFF
--- a/cbits/reedsolomon.h
+++ b/cbits/reedsolomon.h
@@ -15,6 +15,8 @@
 
 PROTO(reedsolomon_gal_mul_avx2);
 PROTO(reedsolomon_gal_mul_xor_avx2);
+PROTO(reedsolomon_gal_mul_avx);
+PROTO(reedsolomon_gal_mul_xor_avx);
 PROTO(reedsolomon_gal_mul_ssse3);
 PROTO(reedsolomon_gal_mul_xor_ssse3);
 PROTO(reedsolomon_gal_mul_sse2);

--- a/cbits/reedsolomon_dispatch.c
+++ b/cbits/reedsolomon_dispatch.c
@@ -73,7 +73,11 @@ static inline ALWAYS_INLINE int __get_cpuid_count(
                 else {                                                                          \
                         IFUNC_AVX2(n, func);                                                    \
                         if(func == NULL) {                                                      \
-                                if((cpuid1.ecx & bit_SSSE3) != 0) {                             \
+                                if((cpuid1.ecx & bit_AVX) != 0) {                               \
+                                        LOG("reedsolomon: using " #n "_avx");                   \
+                                        func = n ## _avx;                                       \
+                                }                                                               \
+                                else if((cpuid1.ecx & bit_SSSE3) != 0) {                        \
                                         LOG("reedsolomon: using " #n "_ssse3");                 \
                                         func = n ## _ssse3;                                     \
                                 }                                                               \


### PR DESCRIPTION
Whilst AVX implementations of the Galois encoding routines were compiled
into the binary, they were never used by the (CPUID-based) dispatching
routines.

This commits fixes this oversight.
