### PR TITLE
cbits: Don't use `-funroll-all-loops`

### DIFF
--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -29,7 +29,7 @@ LT_INIT
 AX_APPEND_COMPILE_FLAGS([-std=c99])
 AX_APPEND_COMPILE_FLAGS([-ggdb3])
 AX_APPEND_COMPILE_FLAGS([-Wall -Wextra])
-AX_APPEND_COMPILE_FLAGS([-O3 -funroll-all-loops])
+AX_APPEND_COMPILE_FLAGS([-O3])
 AX_APPEND_COMPILE_FLAGS([-frecord-gcc-switches -grecord-gcc-switches])
 
 # Check CC has AVX2 support


### PR DESCRIPTION
While performing some more micro-benchmarks this seems to decrease performance slightly.
