### PR TITLE
Bump dependency version bounds

### DIFF
--- a/reedsolomon.cabal
+++ b/reedsolomon.cabal
@@ -106,7 +106,7 @@ Executable reedsolomon-simple-encoder
     Build-Depends:     base
                      , bytestring
                      , vector
-                     , optparse-applicative >= 0.11 && < 0.12
+                     , optparse-applicative >= 0.11 && < 0.13
                      , filepath >= 1.3 && < 1.5
                      , bytestring-mmap >= 0.2 && < 0.3
                      , reedsolomon
@@ -122,7 +122,7 @@ Executable reedsolomon-simple-decoder
     Build-Depends:     base
                      , bytestring
                      , vector
-                     , optparse-applicative >= 0.11 && < 0.12
+                     , optparse-applicative >= 0.11 && < 0.13
                      , filepath >= 1.3 && < 1.5
                      , bytestring-mmap >= 0.2 && < 0.3
                      , reedsolomon
@@ -158,8 +158,8 @@ Executable reedsolomon-profiling
                      , vector
                      , deepseq >= 1.3 && < 1.5
                      , random >= 1.1 && < 1.2
-                     , optparse-applicative >= 0.11 && < 0.12
-                     , clock >= 0.4 && < 0.6
+                     , optparse-applicative >= 0.11 && < 0.13
+                     , clock >= 0.4 && < 0.7
                      , reedsolomon
   Default-Language:    Haskell2010
 


### PR DESCRIPTION
Stackage nightly contains packages with versions outside the previous bounds specified in `reedsolomon.cabal` for `clock` and `optparse-applicative`. Bump the version bounds accordingly.
