### PR TITLE
cbits: Add `rpl_malloc` implementation

### DIFF
--- a/cbits/Makefile.am
+++ b/cbits/Makefile.am
@@ -50,7 +50,8 @@ noinst_LIBRARIES += libreedsolomon-neon.a
 endif
 
 noinst_PROGRAMS = reedsolomon-gal-mul-stdio
-reedsolomon_gal_mul_stdio_LDADD = libreedsolomon.a
+reedsolomon_gal_mul_stdio_LDADD = libreedsolomon.a \
+				  $(LIBOBJS)
 if RS_HAVE_GENERIC
 reedsolomon_gal_mul_stdio_LDADD += libreedsolomon-generic.a
 endif

--- a/cbits/malloc.c
+++ b/cbits/malloc.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <errno.h>
+
+/* A `malloc` which behaves like GNU libc `malloc`:
+ * - Return a valid pointer for size 0
+ * - Set `errno` to `ENOMEM` on `NULL` return (according to POSIX)
+ */
+void * rpl_malloc(const size_t size) {
+        void * result = NULL;
+
+        result = malloc(size == 0 ? 1 : size);
+
+        if(result == NULL) {
+                errno = ENOMEM;
+        }
+
+        return result;
+}


### PR DESCRIPTION
Due to the use of `AC_FUNC_MALLOC` in `configure.ac` (because
`reedsolomon-gal-mul-stdio` uses `malloc`), the `configure` script
checks whether the system `malloc` is according to GNU libc: returning a
valid pointer when allocating 0 bytes, and setting `errno` to `ENOMEM`
on allocation failure.

When cross-compiling, this check can't be executed and the script
pessimistically assumes the target system's `malloc` is foreign. It then
creates a `define` from `malloc` to `rpl_malloc`, which by default
doesn't exist. The `LIBOBJS` variable is extended with `malloc.o` in
order to be able to provide a source file which contains this
function/symbol, which is exactly what this patch does.

There's no use of `malloc` and friends in the SIMD routine code, so this
should have no impact on encoding/decoding of data.
