### PR TITLE
TravisCI: Fix non-cached build

### DIFF
--- a/ci/travisci/cbits-cross/install.sh
+++ b/ci/travisci/cbits-cross/install.sh
@@ -6,5 +6,11 @@ popd
 
 stack \
     --no-terminal \
+    setup \
+    --resolver=$RESOLVER
+
+stack \
+    --no-terminal \
     install \
+    --resolver=$RESOLVER \
     bytestring process process-extras QuickCheck

--- a/ci/travisci/cbits-cross/script.sh
+++ b/ci/travisci/cbits-cross/script.sh
@@ -33,9 +33,9 @@ build $HOST_ISA '' ''
 build arm arm-linux-gnueabihf ''
 build arm-neon arm-linux-gnueabihf '-mfpu=neon'
 
-stack runhaskell reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
     'qemu-arm-static -L /usr/arm-linux-gnueabihf ./reedsolomon-gal-mul-stdio-arm'
-stack runhaskell reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
     'qemu-arm-static -L /usr/arm-linux-gnueabihf ./reedsolomon-gal-mul-stdio-arm-neon'


### PR DESCRIPTION
The `cbits-cross` test suite doesn't correctly run `stack setup` in
order to install GHC etc. This wasn't detected before because of a build
cache being reused.
