### PR TITLE
Add PowerPC AltiVec SIMD support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ addons:
       - gcc-arm-linux-gnueabihf
       - libc6-armhf-cross
       - libc6-dev-armhf-cross
+      - gcc-powerpc64le-linux-gnu
 
 before_install:
   - ci/step.sh travisci before-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ matrix:
       os: osx
     - env: SUITE=cbits-cross RESOLVER=lts-4
 
-sudo: false
+sudo: required
+dist: trusty
+
 cache:
   directories:
     - $HOME/.stack/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 matrix:
   include:
     # Stackage LTS-2 uses GHC 7.8.x, which relies on LLVM 3.4
-    - env: SUITE=build-test-bench RESOLVER=lts-2 LLVM_VERSION=3.4
+    - env: SUITE=build-test-bench RESOLVER=lts-2
     # Stackage LTS-3 uses GHC-7.10.2, which relies on LLVM 3.5
     - env: SUITE=build-test-bench RESOLVER=lts-3 LLVM_VERSION=3.5
     # Stackage LTS-4 uses GHC-7.10.3 which relies on LLVM 3.5

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -72,6 +72,9 @@ main = do
 #if RS_HAVE_NEON
           , Just $ bench "NEON" $ whnf (benchRGM c_reedsolomon_gal_mul_neon) v1048576
 #endif
+#if RS_HAVE_ALTIVEC
+          , Just $ bench "AltiVec" $ whnf (benchRGM c_reedsolomon_gal_mul_altivec) v1048576
+#endif
           ]
       , bgroup "memcpy" [
             bench "memcpy" $ whnf (benchRGM memcpyAsCProto) v1048576
@@ -127,6 +130,9 @@ foreign import ccall unsafe "reedsolomon_gal_mul_generic" c_reedsolomon_gal_mul_
 #endif
 #if RS_HAVE_NEON
 foreign import ccall unsafe "reedsolomon_gal_mul_neon" c_reedsolomon_gal_mul_neon :: CProto
+#endif
+#if RS_HAVE_ALTIVEC
+foreign import ccall unsafe "reedsolomon_gal_mul_altivec" c_reedsolomon_gal_mul_altivec :: CProto
 #endif
 
 foreign import ccall unsafe "memcpy" c_memcpy :: Ptr a -> Ptr a -> CSize -> IO ()

--- a/cbits/Makefile.am
+++ b/cbits/Makefile.am
@@ -49,6 +49,12 @@ libreedsolomon_neon_a_CPPFLAGS = -DTARGET=neon -DHOT
 noinst_LIBRARIES += libreedsolomon-neon.a
 endif
 
+if RS_HAVE_ALTIVEC
+libreedsolomon_altivec_a_SOURCES = $(SIMD_SRC)
+libreedsolomon_altivec_a_CPPFLAGS = -DTARGET=altivec -DHOT
+noinst_LIBRARIES += libreedsolomon-altivec.a
+endif
+
 noinst_PROGRAMS = reedsolomon-gal-mul-stdio
 reedsolomon_gal_mul_stdio_LDADD = libreedsolomon.a \
 				  $(LIBOBJS)
@@ -69,6 +75,9 @@ reedsolomon_gal_mul_stdio_LDADD += libreedsolomon-avx2.a
 endif
 if RS_HAVE_NEON
 reedsolomon_gal_mul_stdio_LDADD += libreedsolomon-neon.a
+endif
+if RS_HAVE_ALTIVEC
+reedsolomon_gal_mul_stdio_LDADD += libreedsolomon-altivec.a
 endif
 
 dist_noinst_SCRIPTS = compare-isa.sh

--- a/cbits/compare-isa.sh
+++ b/cbits/compare-isa.sh
@@ -1,20 +1,42 @@
-#!/bin/bash -xue
+#!/bin/bash -ue
 
-HOST_ISA=x86_64
-OTHER_ISA=armv7-rpi2-linux-gnueabihf
-QEMU_ISA=arm
+HOST_ISA=`uname -p`
 
-test -f Makefile && make distclean
-./configure
-make reedsolomon-gal-mul-stdio
-mv reedsolomon-gal-mul-stdio reedsolomon-gal-mul-stdio-$HOST_ISA
+function build_for_arch() {
+    local isa=$1
+    shift
+    local backend=$1
+    shift
+    local cflags=${1:-}
 
-make distclean
-PATH=~/x-tools/$OTHER_ISA/bin:$PATH ./configure --host=$OTHER_ISA
-PATH=~/x-tools/$OTHER_ISA/bin:$PATH make reedsolomon-gal-mul-stdio
-mv reedsolomon-gal-mul-stdio reedsolomon-gal-mul-stdio-$OTHER_ISA
+    PATH=~/x-tools/$isa/bin:$PATH ./configure --host=$isa CFLAGS="$cflags"
+    PATH=~/x-tools/$isa/bin:$PATH make reedsolomon-gal-mul-stdio
+    mv reedsolomon-gal-mul-stdio reedsolomon-gal-mul-stdio-$isa-$backend
+    make clean
+}
 
-stack runhaskell reedsolomon-gal-mul-stdio-quickcheck.hs -- \
-        -v \
-        ./reedsolomon-gal-mul-stdio-$HOST_ISA \
-        "qemu-$QEMU_ISA -L ~/x-tools/$OTHER_ISA/$OTHER_ISA/sysroot ./reedsolomon-gal-mul-stdio-$OTHER_ISA"
+function test_arch() {
+    local qemu_arch=$1
+    shift
+    local isa=$1
+    shift
+    local backend=$1
+
+    echo "Validating $isa with backend $backend"
+    stack runhaskell reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+        ./reedsolomon-gal-mul-stdio-$HOST_ISA-native \
+        "qemu-$qemu_arch -L ~/x-tools/$isa/$isa/sysroot ./reedsolomon-gal-mul-stdio-$isa-$backend"
+    echo
+}
+
+build_for_arch $HOST_ISA native
+build_for_arch armv7-rpi2-linux-gnueabihf generic '-mfpu=vfp'
+build_for_arch armv7-rpi2-linux-gnueabihf neon '-mfpu=neon'
+# My PPC64 x-tools require `-static` for executables to work with `qemu-ppc64`
+build_for_arch powerpc64-unknown-linux-gnu generic '-static'
+build_for_arch powerpc64-unknown-linux-gnu altivec '-static -maltivec'
+
+test_arch arm armv7-rpi2-linux-gnueabihf generic
+test_arch arm armv7-rpi2-linux-gnueabihf neon
+test_arch ppc64 powerpc64-unknown-linux-gnu generic
+test_arch ppc64 powerpc64-unknown-linux-gnu altivec

--- a/cbits/compare-isa.sh
+++ b/cbits/compare-isa.sh
@@ -21,11 +21,15 @@ function test_arch() {
     local isa=$1
     shift
     local backend=$1
+    local qemu_cpu=''
+    if test -n ${2:-''}; then
+        qemu_cpu="-cpu ${2}"
+    fi
 
-    echo "Validating $isa with backend $backend"
+    echo "Validating $isa with backend $backend on ${2:-generic}"
     stack runhaskell reedsolomon-gal-mul-stdio-quickcheck.hs -- \
         ./reedsolomon-gal-mul-stdio-$HOST_ISA-native \
-        "qemu-$qemu_arch -L ~/x-tools/$isa/$isa/sysroot ./reedsolomon-gal-mul-stdio-$isa-$backend"
+        "qemu-$qemu_arch $qemu_cpu -L ~/x-tools/$isa/$isa/sysroot ./reedsolomon-gal-mul-stdio-$isa-$backend"
     echo
 }
 
@@ -35,8 +39,10 @@ build_for_arch armv7-rpi2-linux-gnueabihf neon '-mfpu=neon'
 # My PPC64 x-tools require `-static` for executables to work with `qemu-ppc64`
 build_for_arch powerpc64-unknown-linux-gnu generic '-static'
 build_for_arch powerpc64-unknown-linux-gnu altivec '-static -maltivec'
+build_for_arch powerpc64-unknown-linux-gnu altivec-power8 '-static -mcpu=power8'
 
 test_arch arm armv7-rpi2-linux-gnueabihf generic
 test_arch arm armv7-rpi2-linux-gnueabihf neon
 test_arch ppc64 powerpc64-unknown-linux-gnu generic
 test_arch ppc64 powerpc64-unknown-linux-gnu altivec
+test_arch ppc64 powerpc64-unknown-linux-gnu altivec-power8 POWER8

--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -108,6 +108,29 @@ CPPFLAGS=$rs_simd_headers_save_flags
 
 AC_CHECK_HEADERS([arm_neon.h], [rs_neon=1], [rs_neon=0])
 AC_CHECK_HEADERS([altivec.h], [rs_altivec=1], [rs_altivec=0])
+# Figure out whether we have POWER8 support
+AC_CACHE_CHECK([whether vec_vsrd works], [rs_cv_vec_vsrd_works],
+    [AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([[
+                #include <altivec.h>
+            ]], [[
+                __vector unsigned long v0 = { 0, 1 },
+                                       v1 = { 2, 3 },
+                                       v2 = vec_vsrd(v0, v1);
+                (void)v2;
+            ]])],
+            [rs_cv_vec_vsrd_works=yes],
+            [rs_cv_vec_vsrd_works=no])])
+
+if test x$rs_cv_vec_vsrd_works = xyes; then
+    rs_have_vec_vsrd=1
+else
+    rs_have_vec_vsrd=0
+fi
+AC_DEFINE_UNQUOTED(
+    [RS_HAVE_VEC_VSRD],
+    [$rs_have_vec_vsrd],
+    [Define to 1 if vec_vsrd works])
 
 # Checks for library functions.
 AC_FUNC_MALLOC
@@ -181,7 +204,11 @@ if test x$rs_neon = x1; then
     rs_backends="$rs_backends, neon"
 fi
 if test x$rs_altivec = x1; then
-    rs_backends="$rs_backends, altivec"
+    if test x$rs_have_vec_vsrd = x1; then
+        rs_backends="$rs_backends, altivec (POWER8)"
+    else
+        rs_backends="$rs_backends, altivec"
+    fi
 fi
 
 rs_backends=`echo $rs_backends | $SED s/^,\ //`

--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -107,16 +107,20 @@ AC_CHECK_HEADERS([immintrin.h])
 CPPFLAGS=$rs_simd_headers_save_flags
 
 AC_CHECK_HEADERS([arm_neon.h], [rs_neon=1], [rs_neon=0])
+AC_CHECK_HEADERS([altivec.h], [rs_altivec=1], [rs_altivec=0])
 
 # Checks for library functions.
 AC_FUNC_MALLOC
 
 # Definitions based on discovered compiler or ISA characteristics.
+rs_generic=1
 if test x$rs_neon = x1; then
     # When building with ARM NEON support, we don't build generic
     rs_generic=0
-else
-    rs_generic=1
+fi
+if test x$rs_altivec = x1; then
+    # When building with PPC AltiVec support, we don't build generic
+    rs_generic=0
 fi
 AM_CONDITIONAL(RS_HAVE_GENERIC, [test x$rs_generic = x1])
 AC_DEFINE_UNQUOTED(
@@ -148,6 +152,11 @@ AC_DEFINE_UNQUOTED(
     [RS_HAVE_NEON],
     [$rs_neon],
     [Define to 1 if NEON works])
+AM_CONDITIONAL(RS_HAVE_ALTIVEC, [test x$rs_altivec = x1])
+AC_DEFINE_UNQUOTED(
+    [RS_HAVE_ALTIVEC],
+    [$rs_altivec],
+    [Define to 1 if AltiVec works])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
@@ -171,6 +180,9 @@ fi
 if test x$rs_neon = x1; then
     rs_backends="$rs_backends, neon"
 fi
+if test x$rs_altivec = x1; then
+    rs_backends="$rs_backends, altivec"
+fi
 
 rs_backends=`echo $rs_backends | $SED s/^,\ //`
 
@@ -189,11 +201,15 @@ Configure completed successfully.
 case $host_cpu in
     arm*)
         if test x$rs_neon = x0; then
-            echo "    WARNING: Not using ARM NEON, performance will be degraded."
+            echo -e "    WARNING: Not using ARM NEON, performance will be degraded.\n"
         fi;;
     i[3456]86*|x86_64*)
         # Assume a compiler which supports AVX/AVX2 also supports SSSE3
         if test x$rs_ssse3 = x0; then
-            echo "    WARNING: Not using Intel SSSE3, performance will be degraded."
+            echo -e "    WARNING: Not using Intel SSSE3, performance will be degraded.\n"
+        fi;;
+    powerpc*)
+        if test x$rs_altivec = x0; then
+            echo -e "    WARNING: Not using PowerPC AltiVec, performance will be degraded.\n"
         fi;;
 esac

--- a/cbits/reedsolomon.h
+++ b/cbits/reedsolomon.h
@@ -41,6 +41,10 @@ PROTO(reedsolomon_gal_mul_xor_generic);
 PROTO(reedsolomon_gal_mul_neon);
 PROTO(reedsolomon_gal_mul_xor_neon);
 #endif
+#if RS_HAVE_ALTIVEC
+PROTO(reedsolomon_gal_mul_altivec);
+PROTO(reedsolomon_gal_mul_xor_altivec);
+#endif
 
 PROTO(reedsolomon_gal_mul);
 PROTO(reedsolomon_gal_mul_xor);
@@ -52,6 +56,7 @@ typedef enum {
         REEDSOLOMON_CPU_AVX = 3,
         REEDSOLOMON_CPU_AVX2 = 4,
         REEDSOLOMON_CPU_NEON = 5,
+        REEDSOLOMON_CPU_ALTIVEC = 6,
 } reedsolomon_cpu_support;
 
 reedsolomon_cpu_support reedsolomon_determine_cpu_support(void);

--- a/cbits/reedsolomon_dispatch.c
+++ b/cbits/reedsolomon_dispatch.c
@@ -166,7 +166,18 @@ reedsolomon_cpu_support reedsolomon_determine_cpu_support(void) {
                 return n ## _neon;              \
         }
 
-#else /* !HAVE_CPUID_H && !RS_HAVE_NEON */
+#elif RS_HAVE_ALTIVEC /* !HAVE_CPUID_H && !RS_HAVE_NEON */
+
+reedsolomon_cpu_support reedsolomon_determine_cpu_support(void) {
+        return REEDSOLOMON_CPU_ALTIVEC;
+}
+
+#define IFUNC(n, proto)                         \
+        static proto n ## _ifunc(void) {        \
+                return n ## _altivec;           \
+        }
+
+#else /* !HAVE_CPUID_H && !RS_HAVE_NEON && !RS_HAVE_ALTIVEC */
 #if !RS_HAVE_GENERIC
 # error Generic routines not available, and no fallback. This is not supported.
 #endif

--- a/ci/travisci/build-test-bench/env.sh
+++ b/ci/travisci/build-test-bench/env.sh
@@ -6,7 +6,12 @@ case "$TRAVIS_OS_NAME" in
     linux)
             TAR_WILDCARDS=--wildcards;
             export TAR_WILDCARDS;
-            STACK_BUILD_OPTIONS=("--ghc-options" "-pgmlo opt-$LLVM_VERSION -pgmlc llc-$LLVM_VERSION'");
+            case "${LLVM_VERSION:-x}" in
+                x)
+                    STACK_BUILD_OPTIONS="--flag=reedsolomon:-LLVM";;
+                *)
+                    STACK_BUILD_OPTIONS=("--ghc-options" "-pgmlo opt-$LLVM_VERSION -pgmlc llc-$LLVM_VERSION'");;
+            esac
             export STACK_BUILD_OPTIONS;;
     osx)
             STACK_BUILD_OPTIONS="--flag=reedsolomon:-LLVM";

--- a/ci/travisci/cbits-cross/before-install.sh
+++ b/ci/travisci/cbits-cross/before-install.sh
@@ -1,6 +1,19 @@
 #!/bin/bash -xue
 
+sudo apt-get -y install libc6-ppc64el-cross libc6-dev-ppc64el-cross
+
 mkdir -p $LOCAL_BIN
 
 curl -L https://www.stackage.org/stack/$TRAVIS_OS_NAME-x86_64 | \
     tar xz --wildcards --strip-components=1 -C $LOCAL_BIN '*/stack'
+
+# The `qemu-user-static` package shipping with TravisCI's Ubuntu version doesn't
+# provide `qemu-ppc64le-static`, which we need to run the PowerPC tests.
+# Retrieve the package from the source repository and 'install' it manually
+# instead...
+pushd /tmp
+QEMU_USER_PKG=qemu-user-static_2.3+dfsg-5ubuntu9.1_amd64.deb
+wget http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/$QEMU_USER_PKG
+dpkg -x $QEMU_USER_PKG qemu-user
+mv qemu-user/usr/bin/qemu-ppc64le-static $LOCAL_BIN/
+popd

--- a/ci/travisci/cbits-cross/script.sh
+++ b/ci/travisci/cbits-cross/script.sh
@@ -32,6 +32,9 @@ HOST_ISA=`uname -p`
 build $HOST_ISA '' ''
 build arm arm-linux-gnueabihf ''
 build arm-neon arm-linux-gnueabihf '-mfpu=neon'
+build ppc64le powerpc64le-linux-gnu '-mno-altivec'
+build ppc64le-altivec powerpc64le-linux-gnu '-maltivec'
+build ppc64le-power8 powerpc64le-linux-gnu '-mcpu=power8'
 
 stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
@@ -39,3 +42,13 @@ stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs --
 stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
     'qemu-arm-static -L /usr/arm-linux-gnueabihf ./reedsolomon-gal-mul-stdio-arm-neon'
+
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+    ./reedsolomon-gal-mul-stdio-$HOST_ISA \
+    'qemu-ppc64le-static -L /usr/powerpc64le-linux-gnu ./reedsolomon-gal-mul-stdio-ppc64le'
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+    ./reedsolomon-gal-mul-stdio-$HOST_ISA \
+    'qemu-ppc64le-static -L /usr/powerpc64le-linux-gnu ./reedsolomon-gal-mul-stdio-ppc64le-altivec'
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+    ./reedsolomon-gal-mul-stdio-$HOST_ISA \
+    'qemu-ppc64le-static -cpu POWER8 -L /usr/powerpc64le-linux-gnu ./reedsolomon-gal-mul-stdio-ppc64le-power8'

--- a/src/Data/ReedSolomon.lhs
+++ b/src/Data/ReedSolomon.lhs
@@ -856,6 +856,7 @@ func (r reedSolomon) Join(dst io.Writer, shards [][]byte, outSize int) error {
 >                       | AVX
 >                       | AVX2
 >                       | NEON
+>                       | AltiVec
 >   deriving (Show, Eq, Ord, Enum, Bounded)
 >
 > -- | Retrieve the SIMD instruction set used by 'native' Galois field operations.

--- a/test/Galois.lhs
+++ b/test/Galois.lhs
@@ -395,6 +395,9 @@ func TestGalois(t *testing.T) {
 #if RS_HAVE_NEON
 > foreign import ccall unsafe "reedsolomon_gal_mul_neon" c_rgm_neon :: CProto
 #endif
+#if RS_HAVE_ALTIVEC
+> foreign import ccall unsafe "reedsolomon_gal_mul_altivec" c_rgm_altivec :: CProto
+#endif
 #endif
 
 > tests :: TestTree
@@ -439,6 +442,10 @@ func TestGalois(t *testing.T) {
 #if RS_HAVE_NEON
 >                       (Just $ testProperty "native/NEON" $
 >                           reedsolomonGalMulEquivalence c_rgm c_rgm_neon) :
+#endif
+#if RS_HAVE_ALTIVEC
+>                       (Just $ testProperty "native/AltiVec" $
+>                           reedsolomonGalMuulEquivalence c_rgm c_rgm_altivec) :
 #endif
 >                       []
 >                 ]


### PR DESCRIPTION
This is currently only tested through `reedsolomon-gal-mul-stdio` and related `QuickCheck` tests, not at the Haskell-level, so not ready for merge. Also, only tested on `ppc64le`.
