### PR TITLE
Make building example binaries optional

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,11 @@ install:
   - 7z x stack.zip stack.exe
   - echo "" | stack setup
   - echo "" | stack exec bash -- -lc "mkdir /tmp; pacman --sync --sysupgrade --needed --refresh --noconfirm autoconf automake make"
-  - echo "" | stack build --test --bench --only-snapshot --flag=reedsolomon:-LLVM
+  - echo "" | stack build --test --bench --only-snapshot --flag=reedsolomon:-LLVM --flag=reedsolomon:examples
 
 build_script:
   - echo "" | stack exec bash -- -lc "cd /c/reedsolomon/cbits; autoreconf -vi"
-  - echo "" | stack build --pedantic --test --no-run-tests --bench --no-run-benchmarks --flag=reedsolomon:-LLVM
+  - echo "" | stack build --pedantic --test --no-run-tests --bench --no-run-benchmarks --flag=reedsolomon:-LLVM --flag=reedsolomon:examples
 
 test_script:
   - echo "" | stack build --pedantic --test --test-arguments "+RTS -N1" --flag=reedsolomon:-LLVM

--- a/ci/travisci/build-test-bench/install.sh
+++ b/ci/travisci/build-test-bench/install.sh
@@ -13,6 +13,7 @@ stack \
     --no-terminal \
     build \
     ${STACK_BUILD_OPTIONS[*]:-} \
+    --flag=reedsolomon:examples \
     --test \
     --bench \
     --only-snapshot \

--- a/ci/travisci/build-test-bench/script.sh
+++ b/ci/travisci/build-test-bench/script.sh
@@ -4,6 +4,7 @@ echo "Running tests with SIMD support disabled"
 stack --no-terminal build \
         --flag=reedsolomon:-SIMD \
         ${STACK_BUILD_OPTIONS[*]:-} \
+        --flag=reedsolomon:examples \
         --pedantic \
         --test \
         --test-arguments "+RTS -N2" \
@@ -16,6 +17,7 @@ stack --resolver=$RESOLVER clean
 echo "Running tests with default settings (SIMD support enabled)"
 stack --no-terminal build \
         ${STACK_BUILD_OPTIONS[*]:-} \
+        --flag=reedsolomon:examples \
         --pedantic \
         --test \
         --test-arguments "+RTS -N2" \

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,10 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install hscolour
 
+  post:
+    - cabal install --upgrade-dependencies --constraint="template-haskell installed" --dependencies-only --enable-tests -fexamples
+    - cabal configure --enable-tests -fexamples
+
 test:
   override:
     - cd cbits; autoreconf -vi

--- a/reedsolomon.cabal
+++ b/reedsolomon.cabal
@@ -54,6 +54,11 @@ Flag LLVM
   Default:      True
   Manual:       True
 
+Flag examples
+  Description:  Build example binaries
+  Default:      False
+  Manual:       True
+
 Library
   Hs-Source-Dirs:      src
   Exposed-Modules:     Data.ReedSolomon
@@ -97,7 +102,7 @@ Executable reedsolomon-simple-encoder
   -- `Build-Depends` goes into the conditional block so Cabal calculates
   -- dependencies correctly, even though `Buildable` is set to `False`.
   -- See https://github.com/haskell/cabal/issues/1725#issuecomment-123783734
-  if !os(windows)
+  if !os(windows) && flag(examples)
     Build-Depends:     base
                      , bytestring
                      , vector
@@ -113,7 +118,7 @@ Executable reedsolomon-simple-decoder
   Hs-Source-Dirs:      examples
   Main-Is:             simple-decoder.lhs
   Ghc-Options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  if !os(windows)
+  if !os(windows) && flag(examples)
     Build-Depends:     base
                      , bytestring
                      , vector
@@ -133,12 +138,15 @@ Executable reedsolomon-simple-bench
     Ghc-Options:       -g
   if flag(LLVM)
     Ghc-Options:       -fllvm
-  Build-Depends:       base
+  if flag(examples)
+    Build-Depends:     base
                      , vector
                      , random >= 1.1 && < 1.2
                      , criterion >= 1.1 && < 1.2
                      , statistics >= 0.13 && < 0.14
                      , reedsolomon
+  else
+    Buildable:         False
   Default-Language:    Haskell2010
 
 Executable reedsolomon-profiling
@@ -149,13 +157,16 @@ Executable reedsolomon-profiling
     Ghc-Options:       -g
   if flag(LLVM)
     Ghc-Options:       -fllvm
-  Build-Depends:       base
+  if flag(examples)
+    Build-Depends:     base
                      , vector
                      , deepseq >= 1.3 && < 1.5
                      , random >= 1.1 && < 1.2
                      , optparse-applicative >= 0.11 && < 0.13
                      , clock >= 0.4 && < 0.7
                      , reedsolomon
+  else
+    Buildable:         False
   Default-Language:    Haskell2010
 
 Test-Suite reedsolomon-test


### PR DESCRIPTION
In general there's no need to build or install the example binaries
when installing this library. This commit adds a flag to enable them
when desired.
