### PR TITLE
cbits: Add AARCH64-specific `vqtbl1q_u8` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ addons:
       - gcc-powerpc64le-linux-gnu
       - cabal-install-1.22
       - ghc-7.10.3
+      - gcc-aarch64-linux-gnu
+      - libc6-arm64-cross
+      - libc6-dev-arm64-cross
 
 before_install:
   - ci/step.sh travisci before-install

--- a/cbits/compare-isa.sh
+++ b/cbits/compare-isa.sh
@@ -40,9 +40,11 @@ build_for_arch armv7-rpi2-linux-gnueabihf neon '-mfpu=neon'
 build_for_arch powerpc64-unknown-linux-gnu generic '-static'
 build_for_arch powerpc64-unknown-linux-gnu altivec '-static -maltivec'
 build_for_arch powerpc64-unknown-linux-gnu altivec-power8 '-static -mcpu=power8'
+build_for_arch aarch64-unknown-linux-musleabi generic '-static'
 
 test_arch arm armv7-rpi2-linux-gnueabihf generic
 test_arch arm armv7-rpi2-linux-gnueabihf neon
 test_arch ppc64 powerpc64-unknown-linux-gnu generic
 test_arch ppc64 powerpc64-unknown-linux-gnu altivec
 test_arch ppc64 powerpc64-unknown-linux-gnu altivec-power8 POWER8
+test_arch aarch64 aarch64-unknown-linux-musleabi generic

--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -148,6 +148,30 @@ AC_CHECK_HEADERS([immintrin.h])
 CPPFLAGS=$rs_simd_headers_save_flags
 
 AC_CHECK_HEADERS([arm_neon.h], [rs_neon=1], [rs_neon=0])
+# Figure out whether we have vqtbl1q_u8 support
+AC_CACHE_CHECK([whether vqtbl1q_u8 works], [rs_cv_vqtbl1q_u8_works],
+    [AC_COMPILE_IFELSE([
+        AC_LANG_PROGRAM([[
+                #include <arm_neon.h>
+            ]], [[
+                const uint8x16_t tab = vdupq_n_u8(1),
+                                 idx = vdupq_n_u8(2),
+                                 result = vqtbl1q_u8(tab, idx);
+
+                (void)result;
+            ]])],
+            [rs_cv_vqtbl1q_u8_works=yes],
+            [rs_cv_vqtbl1q_u8_works=no])])
+if test x$rs_cv_vqtbl1q_u8_works = xyes; then
+    rs_have_vqtbl1q_u8=1
+else
+    rs_have_vqtbl1q_u8=0
+fi
+AC_DEFINE_UNQUOTED(
+    [RS_HAVE_VQTBL1Q_U8],
+    [$rs_have_vqtbl1q_u8],
+    [Define to 1 if vqtbl1q_u8 works])
+
 AC_CHECK_HEADERS([altivec.h], [rs_altivec=1], [rs_altivec=0])
 # Figure out whether we have POWER8 support
 AC_CACHE_CHECK([whether vec_vsrd works], [rs_cv_vec_vsrd_works],
@@ -249,7 +273,11 @@ if test x$rs_avx2 = x1; then
     rs_backends="$rs_backends, avx2"
 fi
 if test x$rs_neon = x1; then
-    rs_backends="$rs_backends, neon"
+    if test x$rs_have_vqtbl1q_u8 = x1; then
+        rs_backends="$rs_backends, neon (AARCH64)"
+    else
+        rs_backends="$rs_backends, neon"
+    fi
 fi
 if test x$rs_altivec = x1; then
     if test x$rs_have_vec_vsrd = x1; then

--- a/ci/travisci/cbits-cross/before-install.sh
+++ b/ci/travisci/cbits-cross/before-install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -xue
 
-sudo apt-get -y install libc6-ppc64el-cross libc6-dev-ppc64el-cross
+sudo apt-get -y install libc6-ppc64el-cross libc6-dev-ppc64el-cross \
+                        libc6-arm64-cross libc6-dev-arm64-cross
 
 mkdir -p $LOCAL_BIN
 

--- a/ci/travisci/cbits-cross/script.sh
+++ b/ci/travisci/cbits-cross/script.sh
@@ -35,6 +35,7 @@ build arm-neon arm-linux-gnueabihf '-mfpu=neon'
 build ppc64le powerpc64le-linux-gnu '-mno-altivec'
 build ppc64le-altivec powerpc64le-linux-gnu '-maltivec'
 build ppc64le-power8 powerpc64le-linux-gnu '-mcpu=power8'
+build aarch64 aarch64-linux-gnu ''
 
 stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
@@ -52,3 +53,6 @@ stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs --
 stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
     ./reedsolomon-gal-mul-stdio-$HOST_ISA \
     'qemu-ppc64le-static -cpu POWER8 -L /usr/powerpc64le-linux-gnu ./reedsolomon-gal-mul-stdio-ppc64le-power8'
+stack runhaskell --resolver=$RESOLVER reedsolomon-gal-mul-stdio-quickcheck.hs -- \
+    ./reedsolomon-gal-mul-stdio-$HOST_ISA \
+    'qemu-aarch64-static -L /usr/aarch64-linux-gnu ./reedsolomon-gal-mul-stdio-aarch64'


### PR DESCRIPTION
This commit adds support for the `vqtbl1q_u8` intrinsic on the AARCH64
platform, replacing the multi-instruction emulation for
`_mm_shuffle_epi8` used on ARM into a single-instruction equivalent.
