### PR TITLE
Tests: Add vector address alignment assertion test

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -101,7 +101,6 @@ customBuildHook innerHook packageDescription@PackageDescription{..} localBuildIn
                         _ -> ["--disable-maintainer-mode"]
                     fromWindows = map (\c -> if c == '\\' then '/' else c)
                 rawSystemExit verbosity "sh" $ [ fromWindows configure
-                                               , "--with-pic"
                                                ] ++ libOptions
 
         rawSystemExit verbosity "make" ["-C", cbitsBuildDir, "--no-print-directory"]

--- a/test/Galois.lhs
+++ b/test/Galois.lhs
@@ -17,6 +17,8 @@
 > import Data.Word (Word8)
 #if HAVE_SIMD
 > import Foreign.C (CSize(..))
+> import qualified Foreign.ForeignPtr.Unsafe as FP
+> import qualified Foreign.Ptr as Ptr
 > import GHC.TypeLits (KnownNat)
 > import System.IO.Unsafe (unsafePerformIO)
 #endif
@@ -398,6 +400,16 @@ func TestGalois(t *testing.T) {
 #if RS_HAVE_ALTIVEC
 > foreign import ccall unsafe "reedsolomon_gal_mul_altivec" c_rgm_altivec :: CProto
 #endif
+>
+> alignmentProperty :: [Word8] -> Bool
+> alignmentProperty = (\ptr -> ptr `rem` 16 == 0)
+>                     . vectorAddress
+>                     . SV.fromList
+>   where
+>     vectorAddress = Ptr.ptrToWordPtr . FP.unsafeForeignPtrToPtr
+>                                      . fst
+>                                      . SV.unsafeToForeignPtr0
+>
 #endif
 
 > tests :: TestTree
@@ -449,6 +461,7 @@ func TestGalois(t *testing.T) {
 #endif
 >                       []
 >                 ]
+>           , testProperty "alignment" alignmentProperty
 >           ]
 #endif
 >     ]


### PR DESCRIPTION
In the `cbits` code, we currently assume input vectors to the `reedsolomon_galois_mul*` procedurues are 16-byte aligned (defined by `_RS_ASSUMED_ALIGNMENT` in `configure.ac`). This should be true, given how storable vectors are allocated, and the GHC RTS always ensuring
16-byte alignment (see https://github.com/ghc/ghc/blob/d3a79bcc035d7dab4f16a807984225e4bd4fccd8/rts/PrimOps.cmm#L71).

To ensure this remains the case in future GHC versions, or whichever version used with this library (though anything after somewhere 2009 should be OK), this commit adds a simple test-case which allocates a bunch of vectors, and validates their address.
