### PR TITLE
cbits: Turn some warnings into errors

### DIFF
--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -58,6 +58,7 @@ AX_GCC_FUNC_ATTRIBUTE([force_align_arg_pointer])
 _AC_LANG_PREFIX[]FLAGS=$rs_gcc_func_attribute_save_flags
 
 ## Checks for supported generic compiler options.
+AX_APPEND_COMPILE_FLAGS([-Werror=unknown-pragmas -Werror=unused-command-line-argument -Werror=unknown-warning-option])
 AX_APPEND_COMPILE_FLAGS([-ggdb3])
 AS_IF([test x$PACKAGE_VERSION = x999],
       AX_APPEND_COMPILE_FLAGS([-Werror]))


### PR DESCRIPTION
In release builds, `-Werror` is not added to `CFLAGS`. This causes some
checks used to validate whether some functionality is available on the
system to generate a warning and succeed, then generating a warning
during compilation as well.

This patch adds some `-Werror=...` for warnings which we want to be
errors.
