### PR TITLE
Fix `cabal repl` support

### DIFF
--- a/build-tools/ghc-wrapper
+++ b/build-tools/ghc-wrapper
@@ -6,6 +6,12 @@ set +e
 # The `tr` below turns Windows path separators into Unix ones for the `grep` to
 # succeed.
 echo $@ | tr '\\' '/' | grep "Data/ReedSolomon/Galois/SIMD\.[a-z_]*o" > /dev/null 2>&1
+RC1=$?
+# Detect GHCi mode (to support `cabal repl`)
+echo $@ | grep \\-\\-interactive > /dev/null 2>&1
+RC2=$?
+
+test ${RC1} -eq 0 -o ${RC2} -eq 0
 RC=$?
 set -e
 


### PR DESCRIPTION
Due to how this package hacks into the Cabal build process, `cabal repl`
didn't work: the `cbits` objects weren't built, and the object files
weren't passed to the GHC invocation correctly.

This commit fixes this hooking into the `replHook` from `Setup.hs`, and
trigger a build of `cbits` objects, and adapting the `ghc-wrapper`
script to detect `--interactive` usage of GHC, and adjust the
command-line arguments accordingly.

Note: `stack repl` doesn't work, because Stack seems to bypass
`Setup.hs` in its implementation, see commercialhaskell/stack#970.

See: https://github.com/commercialhaskell/stack/issues/970
