### PR TITLE
Introduce 'backends'

### DIFF
--- a/bench/profiling.hs
+++ b/bench/profiling.hs
@@ -65,7 +65,7 @@ go enc shards = loop
   where
     loop n | n == 0 = return ()
            | otherwise = do
-                parities <- force `fmap` RS.encode enc shards
+                parities <- force `fmap` RS.encode RS.defaultBackend enc shards
                 parities `seq` loop (n - 1)
 
 makeVector :: (SV.Storable a, Random a, RandomGen g) => g -> Int -> SV.Vector a

--- a/examples/simple-bench.hs
+++ b/examples/simple-bench.hs
@@ -25,7 +25,7 @@ import qualified Data.ReedSolomon as RS
 
 runBench :: RS.Encoder -> RS.Matrix -> IO Double
 runBench encoder shards = do
-    let bench = C.nf (fromJust . RS.encode encoder) shards
+    let bench = C.nf (fromJust . RS.encode RS.defaultBackend encoder) shards
 
     r <- C.benchmark' bench
 

--- a/examples/simple-decoder.lhs
+++ b/examples/simple-decoder.lhs
@@ -172,7 +172,7 @@ func main() {
 >             (\e -> case fromException e of
 >                 Just RS.InvalidShardSize -> Just False
 >                 _ -> Nothing)
->             (RS.verify enc (V.map (fromMaybe V.empty) shards))
+>             (RS.verify RS.defaultBackend enc (V.map (fromMaybe V.empty) shards))
 >             return
 
 	if ok {
@@ -195,11 +195,11 @@ func main() {
 			os.Exit(1)
 		}
 
->         shards' <- RS.reconstruct enc shards
+>         shards' <- RS.reconstruct RS.defaultBackend enc shards
 
 		ok, err = enc.Verify(shards)
 
->         ok' <- RS.verify enc shards'
+>         ok' <- RS.verify RS.defaultBackend enc shards'
 
 		if !ok {
 			fmt.Println("Verification failed after reconstruction, data likely corrupted.")

--- a/examples/simple-encoder.lhs
+++ b/examples/simple-encoder.lhs
@@ -173,7 +173,7 @@ func main() {
 	err = enc.Encode(shards)
 	checkErr(err)
 
->     parities <- RS.encode enc shards
+>     parities <- RS.encode RS.defaultBackend enc shards
 >     let shards' = (V.++) shards parities
 
 	// Write out the resulting files.

--- a/reedsolomon.cabal
+++ b/reedsolomon.cabal
@@ -70,7 +70,8 @@ Library
   Exposed-Modules:     Data.ReedSolomon
                      , Data.ReedSolomon.BuildInfo
                      , Data.Vector.Storable.ByteString
-  Other-Modules:       Data.ReedSolomon.Galois
+  Other-Modules:       Data.ReedSolomon.Backend
+                     , Data.ReedSolomon.Galois
                      , Data.ReedSolomon.Galois.GenTables
                      , Data.ReedSolomon.Matrix
                      , Data.Vector.Generic.Compat
@@ -187,6 +188,7 @@ Test-Suite reedsolomon-test
                      , ReedSolomon
                      , Vector
                      , Data.ReedSolomon
+                     , Data.ReedSolomon.Backend
                      , Data.ReedSolomon.Galois
                      , Data.ReedSolomon.Galois.GenTables
                      , Data.ReedSolomon.Galois.NoAsm
@@ -231,6 +233,7 @@ Benchmark reedsolomon-bench
                      , src
   Main-Is:             Main.hs
   Other-Modules:       Data.ReedSolomon
+                     , Data.ReedSolomon.Backend
                      , Data.ReedSolomon.Galois
                      , Data.ReedSolomon.Galois.GenTables
                      , Data.ReedSolomon.Galois.NoAsm

--- a/src/Data/ReedSolomon/Backend.hs
+++ b/src/Data/ReedSolomon/Backend.hs
@@ -1,0 +1,20 @@
+module Data.ReedSolomon.Backend (
+      Backend(..)
+    ) where
+
+import Data.Word (Word8)
+
+import Control.Monad.ST (ST)
+
+import Data.Vector.Storable as SV (Vector, MVector)
+
+data Backend s = Backend { backendName :: String
+                         , backendGalMulSlice :: Word8
+                                              -> SV.Vector Word8
+                                              -> SV.MVector s Word8
+                                              -> ST s ()
+                         , backendGalMulSliceXor :: Word8
+                                                 -> SV.Vector Word8
+                                                 -> SV.MVector s Word8
+                                                 -> ST s ()
+                         }

--- a/src/Data/ReedSolomon/Galois/NoAsm.lhs
+++ b/src/Data/ReedSolomon/Galois/NoAsm.lhs
@@ -1,5 +1,6 @@
 > module Data.ReedSolomon.Galois.NoAsm (
->       galMulSlice
+>       backend
+>     , galMulSlice
 >     , galMulSliceXor
 >     ) where
 >
@@ -15,6 +16,7 @@
 > import qualified Data.Vector.Storable.Mutable as MV
 >
 > import qualified Data.Vector.Generic.Sized as S
+> import Data.ReedSolomon.Backend (Backend(..))
 > import qualified Data.ReedSolomon.Galois.GenTables as GenTables
 
 //+build !amd64 noasm appengine
@@ -51,3 +53,9 @@ func galMulSliceXor(c byte, in, out []byte) {
 >         let input = V.unsafeIndex in_ n
 >         outn <- MV.unsafeRead out n
 >         MV.unsafeWrite out n (outn `xor` S.index mt input)
+
+> backend :: Backend s
+> backend = Backend { backendName = "NoAsm"
+>                   , backendGalMulSlice = galMulSlice
+>                   , backendGalMulSliceXor = galMulSliceXor
+>                   }

--- a/src/Data/ReedSolomon/Galois/SIMD.lhs
+++ b/src/Data/ReedSolomon/Galois/SIMD.lhs
@@ -1,7 +1,8 @@
 > {-# LANGUAGE DataKinds #-}
 
 > module Data.ReedSolomon.Galois.SIMD (
->       galMulSlice
+>       backend
+>     , galMulSlice
 >     , galMulSliceXor
 >     , CProto
 >     , cProtoToPrim
@@ -22,6 +23,7 @@
 > import qualified Data.Vector.Storable.Mutable as MV
 >
 > import qualified Data.Vector.Generic.Sized as S
+> import Data.ReedSolomon.Backend (Backend(..))
 > import qualified Data.ReedSolomon.Galois.GenTables as GenTables
 
 //+build !noasm
@@ -139,3 +141,9 @@ func galMulSliceXor(c byte, in, out []byte) {
 
 > foreign import ccall unsafe "reedsolomon_gal_mul" c_reedsolomon_gal_mul :: CProto
 > foreign import ccall unsafe "reedsolomon_gal_mul_xor" c_reedsolomon_gal_mul_xor :: CProto
+
+> backend :: Backend s
+> backend = Backend { backendName = "SIMD"
+>                   , backendGalMulSlice = galMulSlice
+>                   , backendGalMulSliceXor = galMulSliceXor
+>                   }


### PR DESCRIPTION
Instead of magically resolving which Galois encoding routines to use,
let a called pass a specific `Backend` structure.

This eases development of custom backends (e.g. an OpenCL one), and
allows to split out the SIMD routine stuff from the main package.
