### PR TITLE
cbits: Detect and use system-provided `__get_cpuid_count`

### DIFF
--- a/cbits/configure.ac
+++ b/cbits/configure.ac
@@ -249,6 +249,15 @@ AC_DEFINE_UNQUOTED(
 
 # Checks for library functions.
 AC_FUNC_MALLOC
+AC_CHECK_DECLS(
+    [[__get_cpuid_count(const unsigned int, const unsigned int, unsigned int *, unsigned int *, unsigned int *, unsigned int *)]],
+    [],
+    [],
+    [[
+        #if defined(HAVE_CPUID_H) && HAVE_CPUID_H
+        # include <cpuid.h>
+        #endif
+    ]])
 
 # Definitions based on discovered compiler or ISA characteristics.
 rs_generic=1

--- a/cbits/reedsolomon_dispatch.c
+++ b/cbits/reedsolomon_dispatch.c
@@ -58,6 +58,22 @@
 # define ALWAYS_INLINE
 #endif
 
+/* The prototype we expect for `__get_cpuid_count`. This is already somewhat
+ * checked by autoconf, but this won't hurt to ensure 'our' version below is
+ * consistent with the 'system' one.
+ */
+static inline int __get_cpuid_count(
+        const unsigned int level,
+        const unsigned int count,
+        unsigned int *eax,
+        unsigned int *ebx,
+        unsigned int *ecx,
+        unsigned int *edx);
+
+/* GCC 6.3.1 includes a predefined version of this function, so we should only
+ * define it on systems which don't have it available from cpuid.h
+ */
+#if !defined(HAVE_DECL___GET_CPUID_COUNT) || !HAVE_DECL___GET_CPUID_COUNT
 static inline ALWAYS_INLINE int __get_cpuid_count(
         const unsigned int level,
         const unsigned int count,
@@ -74,6 +90,7 @@ static inline ALWAYS_INLINE int __get_cpuid_count(
         __cpuid_count(level, count, *eax, *ebx, *ecx, *edx);
         return 1;
 }
+#endif /* !HAVE_DECL___GET_CPUID_COUNT */
 
 struct cpuid_registers {
         unsigned int eax, ebx, ecx, edx;


### PR DESCRIPTION
Starting in GCC 6.3, the `cpuid.h` header provided by the compiler
defines a `__get_cpuid_count` function. If this is the case, redefining
it in one of our modules (`reedsolomon_dispatch.c`) causes compilation
to fail.

This commit adds a check for this declaration in `cpuid.h` to
`configure.ac` so a relevant define is generated at `configure` time,
and moves our definition of `__get_cpuid_count` inside a conditional
block.