### PR TITLE
Bump dependency version bounds

### DIFF
--- a/bench/profiling.hs
+++ b/bench/profiling.hs
@@ -12,6 +12,9 @@ import Text.Printf (printf)
 import System.Random (Random(random), RandomGen, getStdGen)
 
 import Options.Applicative
+#if MIN_VERSION_optparse_applicative(0, 13, 0)
+import Data.Monoid ((<>))
+#endif
 
 import System.Clock (Clock(Monotonic), TimeSpec(sec, nsec), getTime, diffTimeSpec)
 

--- a/examples/simple-decoder.lhs
+++ b/examples/simple-decoder.lhs
@@ -14,6 +14,9 @@
 > import System.IO.Posix.MMap (unsafeMMapFile)
 >
 > import Options.Applicative
+#if MIN_VERSION_optparse_applicative(0, 13, 0)
+> import Data.Monoid ((<>))
+#endif
 >
 > import qualified Data.ByteString as BS
 >

--- a/examples/simple-encoder.lhs
+++ b/examples/simple-encoder.lhs
@@ -15,6 +15,9 @@
 > import qualified Data.Vector.Generic as V
 >
 > import Options.Applicative
+#if MIN_VERSION_optparse_applicative(0, 13, 0)
+> import Data.Monoid ((<>))
+#endif
 >
 > import System.IO.Posix.MMap (unsafeMMapFile)
 >

--- a/reedsolomon.cabal
+++ b/reedsolomon.cabal
@@ -114,7 +114,7 @@ Executable reedsolomon-simple-encoder
     Build-Depends:     base
                      , bytestring
                      , vector
-                     , optparse-applicative >= 0.11 && < 0.13
+                     , optparse-applicative >= 0.11 && < 0.14
                      , filepath >= 1.3 && < 1.5
                      , bytestring-mmap >= 0.2 && < 0.3
                      , reedsolomon
@@ -130,7 +130,7 @@ Executable reedsolomon-simple-decoder
     Build-Depends:     base
                      , bytestring
                      , vector
-                     , optparse-applicative >= 0.11 && < 0.13
+                     , optparse-applicative >= 0.11 && < 0.14
                      , filepath >= 1.3 && < 1.5
                      , bytestring-mmap >= 0.2 && < 0.3
                      , reedsolomon
@@ -170,7 +170,7 @@ Executable reedsolomon-profiling
                      , vector
                      , deepseq >= 1.3 && < 1.5
                      , random >= 1.1 && < 1.2
-                     , optparse-applicative >= 0.11 && < 0.13
+                     , optparse-applicative >= 0.11 && < 0.14
                      , clock >= 0.4 && < 0.8
                      , reedsolomon
   else


### PR DESCRIPTION
Stackage nightly contains a package with a version outside the
previous bounds specified in `reedsolomon.cabal` for
`optparse-applicative`. Bump the version bounds accordingly.

Also, handle the API change fallout: `optparse-applicative` no longer
re-exports a version of `<>`.